### PR TITLE
Adds option to prevent expanding on addMessage()

### DIFF
--- a/lib/php-server-view.coffee
+++ b/lib/php-server-view.coffee
@@ -25,3 +25,6 @@ module.exports =
         message: lines
         className: 'text-error'
       ))
+
+    hide: ->
+      @toggle() if @body.isVisible()

--- a/lib/php-server-view.coffee
+++ b/lib/php-server-view.coffee
@@ -3,7 +3,7 @@
 
 module.exports =
   class PhpServerView extends MessagePanelView
-    addMessage: (lines) ->
+    addMessage: (lines, expand) ->
       for text in lines.split "\n"
         linematch = /in ([a-z\\\/\.\-_]+) on line ([0-9]+)$/i
         match = text.match linematch
@@ -17,7 +17,7 @@ module.exports =
           @add(new PlainMessageView(
             message: text
           ))
-        @toggle() if !@body.isVisible()
+        @toggle() if !@body.isVisible() && expand
         @body.scrollToBottom()
 
     addError: (lines) ->

--- a/lib/php-server-view.coffee
+++ b/lib/php-server-view.coffee
@@ -3,7 +3,7 @@
 
 module.exports =
   class PhpServerView extends MessagePanelView
-    addMessage: (lines, expand) ->
+    addMessage: (lines, logLevel) ->
       for text in lines.split "\n"
         linematch = /in ([a-z\\\/\.\-_]+) on line ([0-9]+)$/i
         match = text.match linematch
@@ -17,7 +17,7 @@ module.exports =
           @add(new PlainMessageView(
             message: text
           ))
-        @toggle() if !@body.isVisible() && expand
+        @toggle() if !@body.isVisible() && logLevel == 'all'
         @body.scrollToBottom()
 
     addError: (lines) ->

--- a/lib/php-server.coffee
+++ b/lib/php-server.coffee
@@ -109,6 +109,10 @@ module.exports =
     @server.overrideErrorlog = atom.config.get('php-server.overrideErrorlog')
     @server.expandOnRequest = atom.config.get('php-server.expandOnRequest')
 
+    # Collapse view if expandOnRequest is checked
+    if !@server.expandOnRequest
+      @view?.hide()
+
     # Listen
     @server.on 'message', (message) =>
       @view?.addMessage message, @server.expandOnRequest

--- a/lib/php-server.coffee
+++ b/lib/php-server.coffee
@@ -29,6 +29,11 @@ module.exports =
       description: 'Redirect error log to panel in Atom. Overrides ini settings. May not work on Windows'
       type: 'boolean'
       default: false
+    expandOnRequest:
+      title: 'Expand on request'
+      description: 'Expand the server console window when new requests are received by the server'
+      type: 'boolean'
+      default: true
 
   server: null
   view: null
@@ -102,10 +107,11 @@ module.exports =
     @server.basePort = atom.config.get('php-server.startPort')
     @server.ini = atom.config.get('php-server.phpIni')
     @server.overrideErrorlog = atom.config.get('php-server.overrideErrorlog')
+    @server.expandOnRequest = atom.config.get('php-server.expandOnRequest')
 
     # Listen
     @server.on 'message', (message) =>
-      @view?.addMessage message
+      @view?.addMessage message, @server.expandOnRequest
 
     @server.on 'error', (err) =>
       console.error err
@@ -124,8 +130,8 @@ module.exports =
     @server.start =>
       @view.setTitle "PHP Server: <a href=\"#{@server.href}\">#{@server.href}</a>", true
 
-      @view.addMessage "Listening on #{@server.href}"
-      @view.addMessage "Document root is #{@server.documentRoot}"
+      @view.addMessage "Listening on #{@server.href}", @server.expandOnRequest
+      @view.addMessage "Document root is #{@server.documentRoot}", @server.expandOnRequest
 
       href = @server.href
       if basename


### PR DESCRIPTION
When you uncheck the Expand on request box, the view in atom stays collapsed as you navigate the pages that the package is serving
