### PR TITLE
replaced jQuery .serialize() as atom does no longer support it in 1.17

### DIFF
--- a/lib/php-server.coffee
+++ b/lib/php-server.coffee
@@ -55,11 +55,11 @@ module.exports =
 
 
   startTree: ->
-    @start atom.packages.getLoadedPackage('tree-view').serialize().selectedPath
+    @start atom.packages.getLoadedPackage('tree-view').mainModule.treeView.selectedPath
 
 
   startTreeRoute: ->
-    [path, basename] = @splitPath atom.packages.getLoadedPackage('tree-view').serialize().selectedPath
+    [path, basename] = @splitPath atom.packages.getLoadedPackage('tree-view').mainModule.treeView.selectedPath
     @start path, basename
 
 


### PR DESCRIPTION
in atom 1.17 jQuery is removed. Therefore .serialize() will not work to get the currently selectedPath in the tree view. I fixed it by accessing the path with `atom.packages.getLoadedPackage('tree-view').mainModule.treeView.selectedPath`
This will fix issue #19