### PR TITLE
Local Network Access override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ styles/php-server.less
 README.md
 package.json
 LICENSE.md
+LICENSE.md
+LICENSE.md
+package.json
+README.md

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ menus/php-server.cson
 LICENSE.md
 styles/php-server.less
 .npmignore
+README.md
+package.json
+LICENSE.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 .DS_Store
 npm-debug.log
 node_modules
+package.json
+README.md
+menus/php-server.cson
+LICENSE.md
+styles/php-server.less
+.npmignore

--- a/lib/php-server-server.coffee
+++ b/lib/php-server-server.coffee
@@ -12,6 +12,7 @@ module.exports =
     overrideErrorlog: true
 
     # Properties
+    allowRemote: false
     documentRoot: null
     routerFile: null
     href: null
@@ -60,6 +61,10 @@ module.exports =
             # Use given file as request router
             options.push @routerFile
 
+          if @allowRemote
+            #override spawned
+            options = []
+            options.push "-S", "0.0.0.0:#{port}"
 
           # Spawn PHP server process
           @server = spawn @path, options, env: process.env, cwd: @documentRoot

--- a/lib/php-server.coffee
+++ b/lib/php-server.coffee
@@ -19,6 +19,11 @@ module.exports =
       description: 'Will search for an empty port starting from here'
       type: 'integer'
       default: 8000
+    allowRemote:
+      title: 'Override for Local Network'
+      description: 'Set the hostname as 0.0.0.0 *wildcard* for local network access'
+      type: 'boolean'
+      default: false
     phpIni:
       title: 'Custom php.ini file'
       description: 'Will replace your standard CLI php.ini settings'
@@ -116,6 +121,7 @@ module.exports =
     @server.path = atom.config.get('php-server.phpPath')
     @server.host = atom.config.get('php-server.localhost')
     @server.basePort = atom.config.get('php-server.startPort')
+    @server.allowRemote = atom.config.get('php-server.allowRemote')
     @server.ini = atom.config.get('php-server.phpIni')
     @server.overrideErrorlog = atom.config.get('php-server.overrideErrorlog')
 


### PR DESCRIPTION
These changes add a simple menu toggle to allow the server to start with a full wildcard - thus enabling port tunneling.
This isn't ideal - it should be using 0.0.255.255 for tighter security, but it doesn't seem to work that way.

These 2 minor file changes allow the possibility of debugging things on local networks - such as from a cellphone.
**Firewall Configuration is REQUIRED - open port 8000 to local networks**